### PR TITLE
Capture and display async render errors

### DIFF
--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,0 +1,20 @@
+export class Logger {
+  entries: [string, any][];
+
+  constructor() {
+    this.entries = [];
+  }
+
+  addToLog = (type, args: any[]) => this.entries.push([type, args]);
+
+  getLog = () => this.entries;
+}
+
+export const setupConsoleLogger = () =>
+  new Proxy(new Logger(), {
+    get: (target, name) =>
+      target[name] ||
+      function wrapper() {
+        target.addToLog(name, Array.prototype.slice.call(arguments));
+      },
+  });

--- a/server/render.ts
+++ b/server/render.ts
@@ -52,26 +52,32 @@ const getWrapperComponent = () => {
   return Promise.resolve();
 };
 
-window.result = getWrapperComponent().then((WrapperComponent) => {
-  act(() => {
-    ReactDOM.render(
-      React.createElement(
-        ErrorBoundary,
-        null,
-        WrapperComponent
-          ? React.createElement(
-              WrapperComponent,
-              window.wrapperProps,
-              React.createElement(Component, window.props)
-            )
-          : React.createElement(Component, window.props)
-      ),
-      window.container,
-      () => {
-        if (window.error) {
-          throw window.error;
-        }
-      }
-    );
+const render = (WrapperComponent) =>
+  new Promise((resolve) => {
+    act(() => {
+      ReactDOM.render(
+        React.createElement(
+          ErrorBoundary,
+          null,
+          WrapperComponent
+            ? React.createElement(
+                WrapperComponent,
+                window.wrapperProps,
+                React.createElement(Component, window.props)
+              )
+            : React.createElement(Component, window.props)
+        ),
+        window.container,
+        resolve
+      );
+    });
   });
-});
+
+window.result = getWrapperComponent().then((WrapperComponent) =>
+  render(WrapperComponent).then(
+    () =>
+      new Promise((resolve, reject) =>
+        setTimeout(() => (window.error ? reject(window.error) : resolve()), 0)
+      )
+  )
+);

--- a/server/runner.ts
+++ b/server/runner.ts
@@ -1,7 +1,7 @@
 import {
   findModuleTests,
   LoadedModule,
-  ResultsAndContext,
+  ResultsContextAndLogger,
   runComponentTest,
   serialiseError,
 } from "./server";
@@ -16,7 +16,7 @@ const runComponentTests = (
   file: string,
   component: any
 ): Promise<TestRunnerResult[]> =>
-  promiseSequence<ResultsAndContext>(
+  promiseSequence<ResultsContextAndLogger>(
     component.tests.map((test) => () =>
       runComponentTest(
         path.join(SEARCH_PATH, file),

--- a/server/setupContainerAndMocks.ts
+++ b/server/setupContainerAndMocks.ts
@@ -1,9 +1,11 @@
 import { Mock, setupMocks } from "./mocks";
+import { Logger } from "./logger";
 
 declare global {
   interface Window {
     container: HTMLElement;
     mocks: Mock[];
+    console: Logger;
   }
 }
 


### PR DESCRIPTION
* Add `setTimeout` after render to capture potential async render errors
* Capture general async errors (via `virtualConsole`) and expose via api for future use

Note on double log entries: https://github.com/facebook/react/issues/10384

Fixes #13 